### PR TITLE
Relax all NPM module versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,30 +48,30 @@
   },
   "dependencies": {
     "bluebird": "^2.9.34",
-    "content-type": "~1.0.1",
-    "http-errors": "~1.3.1",
-    "raw-body": "~2.1.2"
+    "content-type": "^1.0.1",
+    "http-errors": "^1.3.1",
+    "raw-body": "^2.1.2"
   },
   "peerDependencies": {
-    "graphql": "~0.2.6"
+    "graphql": "^0.3.0"
   },
   "devDependencies": {
-    "babel": "5.8.21",
-    "babel-core": "5.8.21",
-    "babel-eslint": "4.0.5",
-    "babel-runtime": "5.8.20",
-    "chai": "3.2.0",
-    "coveralls": "2.11.3",
-    "eslint": "1.1.0",
-    "flow-bin": "0.14.0",
-    "graphql": "~0.2.2",
-    "isparta": "3.0.3",
+    "babel": "^5.8.21",
+    "babel-core": "^5.8.21",
+    "babel-eslint": "^4.0.5",
+    "babel-runtime": "^5.8.20",
+    "chai": "^3.2.0",
+    "coveralls": "^2.11.3",
+    "eslint": "^1.1.0",
+    "flow-bin": "^0.14.0",
+    "graphql": "^0.3.0",
+    "isparta": "^3.0.3",
     "koa": "^0.21.0",
     "koa-mount": "^1.3.0",
-    "mocha": "2.2.5",
+    "mocha": "^2.2.5",
     "multer": "^1.0.3",
-    "sane": "1.1.3",
-    "supertest": "1.0.1",
+    "sane": "^1.1.3",
+    "supertest": "^1.0.1",
     "supertest-as-promised": "2.0.2",
     "thenify": "^3.1.0"
   }


### PR DESCRIPTION
This is just so that koa-graphql could support more projects.