### PR TITLE
Fix parse body bug

### DIFF
--- a/src/parseBody.js
+++ b/src/parseBody.js
@@ -15,6 +15,10 @@ export function parseBody(req, request: Request, next: NodeCallback): void {
       return next(null, req.body);
     }
 
+    if (typeof request.body === 'object' && !(request.body instanceof Buffer)) {
+      return next(null, request.body);
+    }
+
     // Skip requests without content types.
     if (req.headers['content-type'] === undefined) {
       return next();


### PR DESCRIPTION
[koa-bodyparser](https://github.com/koajs/bodyparser) parses the request body into the koa request body (this.request), not the node request body (this.req). Was using that in my app and hit a bug where parseBody.js wouldn't pick up on that.

This PR fixes that :)