### PR TITLE
Fix React rendering for GraphiQL

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -129,7 +129,7 @@ add "&raw" to the end of the URL within a browser.
     }
 
     // Render <GraphiQL /> into the body.
-    React.render(
+    ReactDOM.render(
       React.createElement(GraphiQL, {
         fetcher: graphQLFetcher,
         onEditQuery: onEditQuery,


### PR DESCRIPTION
The 0.5.0 release broke GraphiQL for me but this simple change fixed it.
Btw thanks so much for your work on this and prompt update to 0.5.0. Hugely appreciated!