### PR TITLE
Update GraphiQL version to 7.1

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -8,7 +8,7 @@ type GraphiQLData = {
 };
 
 // Current latest version of GraphiQL.
-const GRAPHIQL_VERSION = '0.7.0';
+const GRAPHIQL_VERSION = '0.7.1';
 
 // Ensures string values are save to be used within a <script> tag.
 function safeSerialize(data) {


### PR DESCRIPTION
The GraphiQL Document Explorer in 7.0 has an issue with attempting to view the details of an Interface type, the issue is resolved in 7.1.