### PR TITLE
500 when response.data is null.

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -38,8 +38,12 @@ const QueryRootType = new GraphQLObjectType({
       },
       resolve: (root, { who }) => 'Hello ' + (who || 'World')
     },
-    thrower: {
+    nonNullThrower: {
       type: new GraphQLNonNull(GraphQLString),
+      resolve: () => { throw new Error('Throws!'); }
+    },
+    thrower: {
+      type: GraphQLString,
       resolve: () => { throw new Error('Throws!'); }
     },
     context: {
@@ -949,6 +953,30 @@ describe('GraphQL-HTTP tests', () => {
 
       expect(response.status).to.equal(200);
       expect(JSON.parse(response.text)).to.deep.equal({
+        data: { thrower: null },
+        errors: [ {
+          message: 'Throws!',
+          locations: [ { line: 1, column: 2 } ]
+        } ]
+      });
+    });
+
+    it('handles query errors from non-null top field errors', async () => {
+      const app = koa();
+
+      app.use(mount(urlString(), graphqlHTTP({
+        schema: TestSchema
+      })));
+
+      const error = await catchError(
+        request(app.listen())
+          .get(urlString({
+            query: '{nonNullThrower}',
+          }))
+      );
+
+      expect(error.response.status).to.equal(500);
+      expect(JSON.parse(error.response.text)).to.deep.equal({
         data: null,
         errors: [ {
           message: 'Throws!',
@@ -974,7 +1002,7 @@ describe('GraphQL-HTTP tests', () => {
 
       expect(response.status).to.equal(200);
       expect(JSON.parse(response.text)).to.deep.equal({
-        data: null,
+        data: { thrower: null },
         errors: [ {
           message: 'Custom error format: Throws!',
         } ]
@@ -1002,7 +1030,7 @@ describe('GraphQL-HTTP tests', () => {
 
       expect(response.status).to.equal(200);
       expect(JSON.parse(response.text)).to.deep.equal({
-        data: null,
+        data: { thrower: null },
         errors: [ {
           message: 'Throws!',
           locations: [ { line: 1, column: 2 } ],

--- a/src/index.js
+++ b/src/index.js
@@ -231,6 +231,14 @@ export default function graphqlHTTP(options: Options): Middleware {
       result = { errors: [ error ] };
     }
 
+    // If no data was included in the result, that indicates a runtime query
+    // error, indicate as such with a generic status code.
+    // Note: Information about the error itself will still be contained in
+    // the resulting JSON payload.
+    // http://facebook.github.io/graphql/#sec-Data
+    if (result && result.data === null) {
+      response.status = 500;
+    }
     // Format any encountered errors.
     if (result && result.errors) {
       result.errors = result.errors.map(formatErrorFn || formatError);
@@ -238,17 +246,17 @@ export default function graphqlHTTP(options: Options): Middleware {
 
     // If allowed to show GraphiQL, present it instead of JSON.
     if (showGraphiQL) {
-      const data = renderGraphiQL({
+      const payload = renderGraphiQL({
         query, variables,
         operationName, result
       });
       response.type = 'text/html';
-      response.body = data;
+      response.body = payload;
     } else {
       // Otherwise, present JSON directly.
-      const data = JSON.stringify(result, null, pretty ? 2 : 0);
+      const payload = JSON.stringify(result, null, pretty ? 2 : 0);
       response.type = 'application/json';
-      response.body = data;
+      response.body = payload;
     }
   };
 }


### PR DESCRIPTION
This matches the described spec behavior that when response.data is null, that indicates a query error. This happens when a top field is Non-Null and produces an error. In that case there is no data for the query and a 500 is an appropriate response status.