### PR TITLE
Do not stringify result if not provided pretty parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -291,7 +291,7 @@ function graphqlHTTP(options: Options): Middleware {
       response.body = payload;
     } else {
       // Otherwise, present JSON directly.
-      const payload = JSON.stringify(result, null, pretty ? 2 : 0);
+      const payload = pretty ? JSON.stringify(result, null, 2) : result;
       response.type = 'application/json';
       response.body = payload;
     }


### PR DESCRIPTION
Leave it to koa to stringify the response. This way, a logger middleware can inspect the body and maybe redact it in the log entry so some fields like authentication tokens don't get logged