### PR TITLE
 feat: Support get context in error formatter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,9 @@ function graphqlHTTP(options: Options): Middleware {
     }
     // Format any encountered errors.
     if (result && result.errors) {
-      (result: any).errors = result.errors.map(err => (formatErrorFn || formatError)(err, context));
+      (result: any).errors = result.errors.map(err =>
+        (formatErrorFn || formatError)(err, context),
+      );
     }
 
     // If allowed to show GraphiQL, present it instead of JSON.

--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,7 @@ function graphqlHTTP(options: Options): Middleware {
     }
     // Format any encountered errors.
     if (result && result.errors) {
-      (result: any).errors = result.errors.map(formatErrorFn || formatError);
+      (result: any).errors = result.errors.map(err => (formatErrorFn || formatError)(err, context));
     }
 
     // If allowed to show GraphiQL, present it instead of JSON.

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export type OptionsData = {
    * fulfilling a GraphQL operation. If no function is provided, GraphQL's
    * default spec-compliant `formatError` function will be used.
    */
-  formatError?: ?(error: GraphQLError) => mixed,
+  formatError?: ?(error: GraphQLError, context?: ?any) => mixed,
 
   /**
    * An optional array of validation rules that will be applied on the document
@@ -276,8 +276,8 @@ function graphqlHTTP(options: Options): Middleware {
     }
     // Format any encountered errors.
     if (result && result.errors) {
-      (result: any).errors = result.errors.map(err =>
-        (formatErrorFn || formatError)(err, context),
+      (result: any).errors = result.errors.map(
+        err => (formatErrorFn ? formatErrorFn(err, context) : formatError(err)),
       );
     }
 


### PR DESCRIPTION
In some cases, I need get context in error formatter.

example: 

Translate error message by ``context.header``, 

If ``accept-language`` is ``en-US``, then output English error message
if ``accept-language`` is ``zh-CN``, then output Chiness error message